### PR TITLE
Fix article

### DIFF
--- a/website/content/en/blog/articles/blech-dcf77/index.md
+++ b/website/content/en/blog/articles/blech-dcf77/index.md
@@ -7,9 +7,6 @@ description: >
 author: Matthias Terber
 resources:
 - src: "**.{png,jpg}"
-  title: "Image #:counter"
-  params:
-    byline: "Photo: Matthias Terber / CC-BY-SA"
 ---
 
 ## What is DCF77?

--- a/website/content/en/blog/articles/core-idea/index.md
+++ b/website/content/en/blog/articles/core-idea/index.md
@@ -10,7 +10,9 @@ resources:
 ---
 
 ## Application example: UART communication
-Let us consider a simple embedded use case. We want to implement a [UART](https://de.wikipedia.org/wiki/Universal_Asynchronous_Receiver_Transmitter) communication. For the sake of simplicity, we focus on the data transmission only. Given a number of bytes in a data buffer, the job is to physically send them via the serial interface one after the other. The implementation is to be done on the bare metal; no operating system, no fancy hardware abstraction layers or library functions. 
+Let us consider a simple embedded use case. We want to implement a [UART](https://de.wikipedia.org/wiki/Universal_Asynchronous_Receiver_Transmitter) communication. For the sake of simplicity, we focus on the data transmission only. Given a number of bytes in a data buffer, the job is to physically send them via the serial interface one after the other.
+
+The implementation is to be done on the bare metal; no operating system, no fancy hardware abstraction layers or library functions. That means that, in our example, the UART peripherial is directly controlled via its hardware registers. Writing a byte to the register `UART1->DR` causes the UART hardware interface to send that byte over the wire. While the transmission is in progress, the flag `UART1_FLAG_TXE` is `true`. The interface will automatically set the flag to `false` after it has finished sending the byte. At that time, it can also trigger an interrupt to indicate that the job is done.  
 
 Apart from the sole functional correctness it is important that the application is generally compatible with the stringent constraints of the embedded domain. That is, very limited resources -- *computation time* and *memory* -- and possible *realtime requirements*. Keeping the embedded software reactive is key in order to handle realtime-critical events in time.
 

--- a/website/content/en/blog/articles/core-idea/index.md
+++ b/website/content/en/blog/articles/core-idea/index.md
@@ -121,7 +121,7 @@ As a conclusion we can say that the *event-based style* makes it generally
 {{% /alert %}}
 
 
-## Lifting the abstraction level - the pseudo-blocking style
+## Lifting the abstraction level -- the pseudo-blocking style
 
 Looking back to above implementation schemes the following becomes apparent:
 * The blocking style, on the one hand, typically leads to good software quality but is generally not applicable in the embedded domain.
@@ -130,7 +130,7 @@ Looking back to above implementation schemes the following becomes apparent:
 What if we lived in a *perfect world* where we could cherry-pick and combine the advantages of both approaches? -- Welcome to Blech!
 
 {{% alert title="Basic Idea" color="info"%}}
-The basic idea behind Blech is to let the software developer write code in a *blocking fashion* (good software quality) and systematically compile it into an efficient, deterministic, *event-driven* statemachine implementation (fit embedded domain). By this, Blech code allows to recover all the software engineering advantages mentioned above and, at the same time, fulfills the stringent embedded constraints. This combination is usually hard to achieve and makes Blech *lifting embedded programming to the next level*.
+The basic idea behind Blech is to let the software developer write code in a *blocking fashion* (good software quality) and systematically compile it into an efficient, deterministic, *event-driven* statemachine implementation (fit embedded domain). By this, Blech code allows to recover all the software engineering advantages mentioned above and, at the same time, fulfills the stringent embedded constraints. This combination is usually hard to achieve and makes Blech *lifting embedded programming to a higher level of abstraction*.
 {{% /alert %}}
 
 This concept is what I call the *pseudo-blocking* style. Your software looks and logically behaves like blocking code but is actually non-blocking under the hood. On the bare metal, it can easily interleave its execution with other synchronous or asynchronous parts of your software. For example, there could be some cryptographic algorithm asynchronously running in a background task while your Blech program continously reacts on incoming events.


### PR DESCRIPTION
You might have to explicitly clear hugo's cache in order to ensure that the license information is actually removed from the pre-processed images.