### PR TITLE
Update to new German Medienstaatsvertrag

### DIFF
--- a/website/content/en/about/corporate-information.md
+++ b/website/content/en/about/corporate-information.md
@@ -8,10 +8,10 @@ weight: 10
 
 ### Name and address
 
-Robert Bosch GmbH    
-Corporate Research    
-Robert-Bosch-Campus 1   
-71272 Renningen    
+Robert Bosch GmbH  
+Corporate Research  
+Robert-Bosch-Campus 1  
+71272 Renningen  
 GERMANY
 
 ### Members of the Board of Management
@@ -20,7 +20,7 @@ Dr. Volkmar Denner, Prof. Dr. Stefan Asenkerschbaumer, Dr. Michael Bolle, Dr. Ch
 
 ### Your contact at Bosch Research
 
-<i class="fas fa-envelope"></i> [opensource@bosch.com](mailto:opensource@bosch.com)    
+<i class="fas fa-envelope"></i> [opensource@bosch.com](mailto:opensource@bosch.com)  
 <i class="fas fa-link"></i> [www.bosch.com/research](https://www.bosch.com/research)
 
 ### Register Entries
@@ -31,13 +31,11 @@ Registration Court: District Court Stuttgart HRB 14000
 
 DE811128135
 
-### Responsible in the sense of § 55 Abs. 2 Staatsvertrag für Rundfunk und Telemedien
-Robert Bosch GmbH    
-Corporate Research    
+### Responsible in accordance with section 18 II of Germany’s Interstate Treaty on Media (MStV)
+
+Robert Bosch GmbH  
+Corporate Research  
 Franz-Josef Grosch  
-Robert-Bosch-Campus 1   
-71272 Renningen    
+Robert-Bosch-Campus 1  
+71272 Renningen  
 GERMANY
-
-
-


### PR DESCRIPTION
Germany’s Interstate Treaty on Media (Medienstaatsvertrag, [MStV](https://www.gesetze-bayern.de/Content/Document/MStV/true)) has
come into force on November 7th, 2020. It replaces the State Treaty on
Broadcasting (Rundfunkstaatsvertrag).